### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The input element on which the plugin should listen for keyboard event and trigg
 
 ### resultsContainer (Element) [required]
 
-The container element in which the search results should be rendered in. Typically and `<ul>`.
+The container element in which the search results should be rendered in. Typically an `<ul>`.
 
 
 ### dataSource (String|JSON) [required]


### PR DESCRIPTION
I suppose you wanted to say `an <ul>` instead of `and <ul>`.

If this for some reason was on purpose, please feel free to close this.

Thanks again for making this, and have a nice day!