### PR TITLE
Tags join & bower ignore filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ layout: none
     {
       "title"    : "{{ post.title | escape }}",
       "category" : "{{ post.category }}",
-      "tags"     : "{{ post.tags | array_to_sentence_string }}",
+      "tags"     : "{{ post.tags | join: ', ' }}",
       "url"      : "{{ site.baseurl }}{{ post.url }}",
       "date"     : "{{ post.date }}"
     } {% unless forloop.last %},{% endunless %}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "Simple-Jekyll-Search",
-  "version": "1.0.0",
+  "name": "simple-jekyll-search",
+  "version": "1.0.2",
   "description": "Simple Jekyll site search using javascript and json",
-  "main": "dest/jekyll-search.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "./node_modules/gulp/bin/gulp.js && ./node_modules/karma/bin/karma start test/karma.conf.js --single-run --no-auto-watch",
     "watch-test": "./node_modules/karma/bin/karma start test/karma.conf.js --auto-watch"


### PR DESCRIPTION
# Tags join

Since `array_to_sentence_string` is making list `one, two and three` (who needs “and” for a pure data?) and `join: ', '` is just joining array to a string with `, ` as a separator.

# Bower ignore filter

No one needs source files and JSON data samples in bower package, there are only two needed files:

- jekyll-search.js
- README.md

That why ignore filter is adjusted accordingly:

1. Exclude all
2. Include needed files back

And package size went down from 25 to 10 KB.