### PR TITLE
Replace null layout name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ idea from this [blog post](https://alexpearce.me/2012/04/simple-jekyll-searching
 
 ```
 ---
-layout: none
+layout: null
 ---
 [
   {% for post in site.posts %}

--- a/search.json
+++ b/search.json
@@ -1,5 +1,5 @@
 ---
-layout: none
+layout: null
 ---
 [
   {% for post in site.posts %}


### PR DESCRIPTION
Jekyll throws a warning when using the layout `none`:

```
Build Warning: Layout 'none' requested in feeds/search.json does not exist.
```

It should be `null` instead.