### PR TITLE
Page search & character strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,28 +162,6 @@ You can limit the number of posts rendered on the page.
 Enable fuzzy search to allow less restrictive matching.
 
 
-## Enable full content search
-
-- Replace 'search.json' with the following code:
-
-```
----
-layout: null
----
-[
-  {% for post in site.posts %}
-    {
-      "title"    : "{{ post.title | escape }}",
-      "category" : "{{ post.category }}",
-      "tags"     : "{{ post.tags | array_to_sentence_string }}",
-      "url"      : "{{ site.baseurl }}{{ post.url }}",
-      "date"     : "{{ post.date }}",
-      "content"  : "{{ post.content | strip_html | strip_newlines | escape }}"
-    } {% unless forloop.last %},{% endunless %}
-  {% endfor %}
-]
-```
-
 ## Enable full content search of posts and pages
 
 - Replace 'search.json' with the following code:

--- a/README.md
+++ b/README.md
@@ -162,8 +162,75 @@ You can limit the number of posts rendered on the page.
 Enable fuzzy search to allow less restrictive matching.
 
 
+## Enable full content search
 
+- Replace 'search.json' with the following code:
 
+```
+---
+layout: null
+---
+[
+  {% for post in site.posts %}
+    {
+      "title"    : "{{ post.title | escape }}",
+      "category" : "{{ post.category }}",
+      "tags"     : "{{ post.tags | array_to_sentence_string }}",
+      "url"      : "{{ site.baseurl }}{{ post.url }}",
+      "date"     : "{{ post.date }}",
+      "content"  : "{{ post.content | strip_html | strip_newlines | escape }}"
+    } {% unless forloop.last %},{% endunless %}
+  {% endfor %}
+]
+```
+
+## Enable full content search of posts and pages
+
+- Replace 'search.json' with the following code:
+
+```
+---
+layout: null
+---
+[
+  {% for post in site.posts %}
+    {
+      "title"    : "{{ post.title | escape }}",
+      "category" : "{{ post.category }}",
+      "tags"     : "{{ post.tags | join: ', ' }}",
+      "url"      : "{{ site.baseurl }}{{ post.url }}",
+      "date"     : "{{ post.date }}",
+      "content"  : "{{ post.content | strip_html | strip_newlines }}"
+    } {% unless forloop.last %},{% endunless %}
+  {% endfor %}
+  ,
+  {% for page in site.pages %}
+   {
+     {% if page.title != nil %}
+        "title"    : "{{ page.title | escape }}",
+        "category" : "{{ page.category }}",
+        "tags"     : "{{ page.tags | join: ', ' }}",
+        "url"      : "{{ site.baseurl }}{{ page.url }}",
+        "date"     : "{{ page.date }}",
+        "content"  : "{{ page.content | strip_html | strip_newlines }}"
+     {% endif %}
+   } {% unless forloop.last %},{% endunless %}
+  {% endfor %}
+]
+```
+
+### If search isn't working due to invalid JSON
+
+- There is a filter plugin in the _plugins folder which should remove most characters that cause invalid JSON. To use it, add the simple_search_filter.rb file to your _plugins folder, and use `remove_chars` as a filter.
+
+For example: in search.json, replace 
+```
+"content"  : "{{ page.content | strip_html | strip_newlines }}"
+```
+with 
+```
+"content"  : "{{ page.content | strip_html | strip_newlines | remove_chars | escape }}"
+```
 
 
 ##Browser support

--- a/_plugins/simple_search_filter.rb
+++ b/_plugins/simple_search_filter.rb
@@ -1,0 +1,19 @@
+module Jekyll
+  module CharFilter
+    def remove_chars(input)
+      input.gsub! '\\','&#92;'
+      input.gsub! /\t/, '    '
+      input.strip_control_and_extended_characters
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::CharFilter)
+
+class String
+  def strip_control_and_extended_characters()
+    chars.each_with_object("") do |char, str|
+      str << char if char.ascii_only? and char.ord.between?(32,126)
+    end
+  end
+end

--- a/search.json
+++ b/search.json
@@ -8,7 +8,7 @@ layout: null
       "category" : "{{ post.category }}",
       "tags"     : "{{ post.tags | array_to_sentence_string }}",
       "url"      : "{{ site.baseurl }}{{ post.url }}",
-      "date"     : "{{ post.date }}"
+      "date"     : "{{ post.date }}",
       "content"  : "{{ post.content | strip_html | strip_newlines | remove_chars | escape }}"
     } {% unless forloop.last %},{% endunless %}
   {% endfor %}

--- a/search.json
+++ b/search.json
@@ -9,6 +9,7 @@ layout: null
       "tags"     : "{{ post.tags | array_to_sentence_string }}",
       "url"      : "{{ site.baseurl }}{{ post.url }}",
       "date"     : "{{ post.date }}"
+      "content"  : "{{ post.content | strip_html | strip_newlines | remove_chars | escape }}"
     } {% unless forloop.last %},{% endunless %}
   {% endfor %}
 ]

--- a/search.json
+++ b/search.json
@@ -8,8 +8,7 @@ layout: null
       "category" : "{{ post.category }}",
       "tags"     : "{{ post.tags | array_to_sentence_string }}",
       "url"      : "{{ site.baseurl }}{{ post.url }}",
-      "date"     : "{{ post.date }}",
-      "content"  : "{{ post.content | strip_html | strip_newlines | remove_chars | escape }}"
+      "date"     : "{{ post.date }}"
     } {% unless forloop.last %},{% endunless %}
   {% endfor %}
 ]


### PR DESCRIPTION
Updated readme to document page search. 
Added a plugin to strip characters that will cause invalid JSON.

(Sorry about the use of a plugin; I'm new to Ruby & Jekyll, and couldn't figure out a better way to remove some characters from the JSON)