### PR TITLE
Update npm package & version unification

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-jekyll-search",
-  "version": "2.0.0",
+  "version": "1.0.6",
   "homepage": "http://christian-fei.github.io/Simple-Jekyll-Search/",
   "authors": [
     "Christian Fei"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "simple-jekyll-search",
-  "version": "1.0.2",
+  "version": "1.0.6",
   "description": "Simple Jekyll site search using javascript and json",
-  "main": "src/index.js",
+  "main": "dest/jekyll-search.js",
   "scripts": {
     "test": "./node_modules/gulp/bin/gulp.js && ./node_modules/karma/bin/karma start test/karma.conf.js --single-run --no-auto-watch",
     "watch-test": "./node_modules/karma/bin/karma start test/karma.conf.js --auto-watch"
@@ -13,6 +13,11 @@
   },
   "author": "Christian Fei",
   "license": "MIT",
+  "ignore": [
+    "*",
+    "!dest/jekyll-search.js",
+    "!README.md"
+  ],
   "bugs": {
     "url": "https://github.com/christian-fei/Simple-Jekyll-Search/issues"
   },


### PR DESCRIPTION
Noticed some version number mismatches, npm grabbed an older 1.0.2 version and the bower version defined was 2.0.0 while the actual most recent version is 1.0.6. This PR unifies both, the npm & bower version number.

Additionally, the package installed over npm will be the same file structure as the current bower package, with all files ignored except for `dest/jekyll-search.js` & `README.md`.