### PR TITLE
Add SimpleJekyllSearchInit function call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,10 @@
 
   // for backwards compatibility
   window.SimpleJekyllSearch.init = window.SimpleJekyllSearch
-
+  
+  if (typeof window.SimpleJekyllSearchInit === 'function') {
+    window.SimpleJekyllSearchInit.call(this, window.SimpleJekyllSearch);
+  }
 
   function initWithJSON(json){
     repository.put(json)


### PR DESCRIPTION
I've added a simple check for a `window.SimpleJekyllSearchInit` function — if it exists, the library calls it at load time.

Because the search functionality is not crucial for loading the page, it shouldn't block the rendering. As such, I prefer to include the script with the `async` attribute. However, initialising it becomes less trivial because `window.SimpleJekyllSearch` might not be available yet when the other scripts load.

This PR would solve this problem as such:

```html
<!-- _includes/scripts.html -->
<script src="/js/main.js"></script>
<script async src="/js/jekyll-search.min.js"></script>
```

```js
<!-- main.js -->
var initSearch = function () {
    SimpleJekyllSearch({
      searchInput: document.getElementById('search-input'),
      resultsContainer: document.getElementById('results-container'),
      json: '/search.json',
    });         
};

if (window.SimpleJekyllSearch) {
    // If the library is available, initialise it right away
    initSearch();
} else {
    // Otherwise queue it for when it becomes available
    window.SimpleJekyllSearchInit = initSearch;
}
```