### PR TITLE
fix disappearing results

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,11 +82,13 @@
 
   function registerInput(){
     options.searchInput.addEventListener('keyup', function(e){
-      emptyResultsContainer();
       var key = e.which
-      var query = e.target.value
-      if( isWhitelistedKey(key) && isValidQuery(query) ) {
-        render( repository.search(query) );
+      if( isWhitelistedKey(key) ) {
+        emptyResultsContainer();
+        var query = e.target.value
+        if( isValidQuery(query) ) {
+          render( repository.search(query) );
+        }
       }
     })
   }


### PR DESCRIPTION
Miserably https://github.com/christian-fei/Simple-Jekyll-Search/commit/f34a2b019f3d9faff5ff11c56fb2d130730cfda6 introduced a regression which was reported in https://github.com/christian-fei/Simple-Jekyll-Search/issues/64.

This PR should enable clearing results if there is no query at all and reenable old behavior if arrow keys are pressed for example.

Cheers
midzer