### PR TITLE
Move standard's globals where they are being used.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,16 +40,9 @@
     "uglify-js": "^3.0.28"
   },
   "standard": {
-    "globals": [
-      "test",
-      "beforeEach",
-      "afterEach",
-      "XMLHttpRequest",
-      "ActiveXObject"
-    ],
     "ignore": [
-      "example",
-      "dest"
+      "dest/",
+      "example/"
     ]
   },
   "testling": {

--- a/src/JSONLoader.js
+++ b/src/JSONLoader.js
@@ -1,3 +1,5 @@
+/* globals ActiveXObject:false, XMLHttpRequest:false */
+
 'use strict'
 module.exports = {
   load: load

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,3 +1,5 @@
+/* globals test */
+
 'use strict'
 
 const {equal, ok} = require('assert')


### PR DESCRIPTION
This is much better than having them available everywhere.

/CC @christian-fei 