### PR TITLE
- Update Repository.js and add plugin for non-ASCII chars

### DIFF
--- a/dest/simple-jekyll-search.js
+++ b/dest/simple-jekyll-search.js
@@ -170,6 +170,7 @@ function addObject(_data) {
 
 function addArray(_data) {
   var added = []
+  clear()
   for (var i = 0, len = _data.length; i < len; i++) {
     if (isObject(_data[i])) {
       added.push(addObject(_data[i]))

--- a/example/_plugins/simple_search_filter_cn.rb
+++ b/example/_plugins/simple_search_filter_cn.rb
@@ -1,0 +1,18 @@
+module Jekyll
+  module CharFilter
+    def remove_chars_cn(input)
+      input.gsub! '\\','&#92;'
+      input.gsub! /\t/, '    '
+	  input.gsub! '@',''
+	  input.gsub! '$',''
+	  input.gsub! '%',''
+	  input.gsub! '&',''
+	  input.gsub! '"',''
+	  input.gsub! '{',''
+	  input.gsub! '}',''
+	  input
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::CharFilter)

--- a/example/js/simple-jekyll-search.js
+++ b/example/js/simple-jekyll-search.js
@@ -170,6 +170,7 @@ function addObject(_data) {
 
 function addArray(_data) {
   var added = []
+  clear()
   for (var i = 0, len = _data.length; i < len; i++) {
     if (isObject(_data[i])) {
       added.push(addObject(_data[i]))

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -46,6 +46,7 @@ function addObject(_data) {
 
 function addArray(_data) {
   var added = []
+  clear()
   for (var i = 0, len = _data.length; i < len; i++) {
     if (isObject(_data[i])) {
       added.push(addObject(_data[i]))


### PR DESCRIPTION
- Update Repository.js

Problem description: when I was calling function SimpleJekyllSearch several times on the same page, the resultsContainer will duplicate the search results.
Method to solve: use built-in clear method to clear the global variable 'data' before inserting again.
See the gif below.

Without clear()
![without-clear-duplicate-results](https://user-images.githubusercontent.com/9660181/36060202-98e28f14-0e7f-11e8-8048-ea4a65485352.gif)

With clear()
![with-clear](https://user-images.githubusercontent.com/9660181/36060203-9914d424-0e7f-11e8-9be0-0cfb38e3652c.gif)

- Update simple_search_filter.rb

check https://github.com/christian-fei/Simple-Jekyll-Search/issues/63
The problem seems to be related with special chars in the content field. As the former plugin deals with English text within the range of ACSII, my added plugin works well with my Chinese context. But it seems the full text search is not in readme anymore?


Not so sure if it's eligible since it's my first pull request.😅 .min.js was not editted. 
Thanks for your development and it really worked fine for me!