### PR TITLE
Multi word search

### DIFF
--- a/dest/simple-jekyll-search.js
+++ b/dest/simple-jekyll-search.js
@@ -118,7 +118,16 @@ function LiteralSearchStrategy () {
       return false
     }
     str = str.trim()
-    return str.toLowerCase().indexOf(crit.toLowerCase()) >= 0
+    
+    var search = crit.split(" ")
+    var match = true
+    for (var i = 0; i < search.length; i++) {
+        if(str.toLowerCase().indexOf(search[i].toLowerCase()) == -1) { 
+            match = false
+        }
+    }
+
+    return match
   }
 }
 

--- a/dest/simple-jekyll-search.js
+++ b/dest/simple-jekyll-search.js
@@ -124,6 +124,7 @@ function LiteralSearchStrategy () {
     for (var i = 0; i < search.length; i++) {
         if(str.toLowerCase().indexOf(search[i].toLowerCase()) == -1) { 
             match = false
+            break
         }
     }
 


### PR DESCRIPTION
Add multiple word searches that are not directly behind each other with LiteralSearchStrategy.
The `simple-jekyll-search.min.js` is not updated, also not the version number! 

Modification in action [https://jackgruber.github.io ](https://jackgruber.github.io/pages/search/)