### PR TITLE
Use unpkg.com instead of RawGit

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ For example in  **_layouts/default.html**:
 <!-- script pointing to jekyll-search.js -->
 <script src="{{ site.baseurl }}/simple-jekyll-search.min.js"></script>
 
-<!-- or -->
-<script src="https://cdn.rawgit.com/christian-fei/Simple-Jekyll-Search/master/dest/simple-jekyll-search.min.js"></script>
+<!-- or without installing anything -->
+<script src="https://unpkg.com/simple-jekyll-search/dest/simple-jekyll-search.min.js"></script>
 ```
 
 


### PR DESCRIPTION
Because of this:

> RawGit is now in a sunset phase and will soon shut down. It's been a fun five years, but all things must end.
> 
> GitHub repositories that served content through RawGit within the last month will continue to be served until at least October of 2019