### PR TITLE
Call success on merged options object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@
   })
   var utils = require('./utils')
 
-  var simpleJekyllSearch = function (_options) {
+  window.SimpleJekyllSearch = function (_options) {
     var errors = optionsValidator.validate(_options)
     if (errors.length > 0) {
       throwError('You must specify the following required options: ' + requiredOptions)
@@ -52,15 +52,12 @@
       initWithURL(options.json)
     }
 
-    return {
+    var rv = {
       search: search
     }
-  }
-
-  window.SimpleJekyllSearch = function (_options) {
-    var search = simpleJekyllSearch(_options)
-    _options.success.call(search)
-    return search
+    
+    options.success.call(rv)
+    return rv
   }
 
   function initWithJSON (json) {

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@
     var rv = {
       search: search
     }
-    
+
     options.success.call(rv)
     return rv
   }


### PR DESCRIPTION
This calls success from the merged options instead of only the options provided by the user.

This fixes a TypeError reported in christian-fei/Simple-Jekyll-Search#146.