### PR TITLE
Disable default layouts for documents with a `layout: none` declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This file will be used as a small data source to perform the searches on the cli
 
 ```
 ---
-layout: null
+layout: none
 ---
 [
   {% for post in site.posts %}

--- a/example/search.json
+++ b/example/search.json
@@ -1,5 +1,5 @@
 ---
-layout: null
+layout: none
 ---
 [
   {% for post in site.posts %}


### PR DESCRIPTION
I have an issue with `layout: null` declaration on Jekyll version 4.1, what happens is rendered default layout and make my `search.json` format is invalid, then I found the solution for this problem. 

Based on the discussion https://github.com/jekyll/jekyll/issues/5929 and reference to https://github.com/jekyll/jekyll/pull/5933, So I change a bit the guidelines to avoid someone falls at the same issue.

Thanks.