### PR TITLE
Add a way to limit how many times the search function can be executed over a given time window (debouncing)

### DIFF
--- a/WIKI.md
+++ b/WIKI.md
@@ -117,6 +117,12 @@ Enable fuzzy search to allow less restrictive matching.
 
 Pass in a list of terms you want to exclude (terms will be matched against a regex, so urls, words are allowed).
 
+### debounceTime (Number) [optional]
+
+Limit how many times the search function can be executed over the given time window. This is especially useful to improve the user experience when searching
+over a large dataset (either with rare terms ou because the number of posts to display is large). If no `debounceTime` is provided a search will be triggered
+on each keystroke.
+
 
 ---
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,18 @@
     noResultsText: 'No results found',
     limit: 10,
     fuzzy: false,
+    debounceTime: null,
     exclude: []
+  }
+
+  let debounceTimerHandle
+  const debounce = function (func, delayMillis) {
+    if (delayMillis) {
+      clearTimeout(debounceTimerHandle)
+      debounceTimerHandle = setTimeout(func, delayMillis)
+    } else {
+      func.call()
+    }
   }
 
   const requiredOptions = ['searchInput', 'resultsContainer', 'json']
@@ -86,7 +97,7 @@
     options.searchInput.addEventListener('input', function (e) {
       if (isWhitelistedKey(e.which)) {
         emptyResultsContainer()
-        search(e.target.value)
+        debounce(function () { search(e.target.value) }, options.debounceTime)
       }
     })
   }


### PR DESCRIPTION
Add the necessary code and option for limiting how many times the search function can be executed over a given time window. The technique used to achieve this goal is called "Debouncing" (see https://www.telerik.com/blogs/debouncing-and-throttling-in-javascript) and the debouce time is controlled by a new option : debounceTime.

Supporting debouncing is especially useful to improve the user experience when searching over a large dataset (either with rare terms ou because the number of posts to display is large). If no debounceTime is provided a search will be triggered on each keystroke (the behavior before this option was introduced).