### PR TITLE
Fix the bug of 'exclude' option

### DIFF
--- a/src/Repository.js
+++ b/src/Repository.js
@@ -21,6 +21,7 @@ opt.fuzzy = false
 opt.limit = 10
 opt.searchStrategy = opt.fuzzy ? FuzzySearchStrategy : LiteralSearchStrategy
 opt.sort = NoSort
+opt.exclude = []
 
 function put (data) {
   if (isObject(data)) {
@@ -74,6 +75,7 @@ function setOptions (_opt) {
   opt.limit = _opt.limit || 10
   opt.searchStrategy = _opt.fuzzy ? FuzzySearchStrategy : LiteralSearchStrategy
   opt.sort = _opt.sort || NoSort
+  opt.exclude = _opt.exclude || []
 }
 
 function findMatches (data, crit, strategy, opt) {
@@ -96,13 +98,11 @@ function findMatchesInObject (obj, crit, strategy, opt) {
 }
 
 function isExcluded (term, excludedTerms) {
-  let excluded = false
-  excludedTerms = excludedTerms || []
   for (let i = 0, len = excludedTerms.length; i < len; i++) {
     const excludedTerm = excludedTerms[i]
-    if (!excluded && new RegExp(term).test(excludedTerm)) {
-      excluded = true
+    if (new RegExp(excludedTerm).test(term)) {
+      return true
     }
   }
-  return excluded
+  return false
 }

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,8 @@
     repository.setOptions({
       fuzzy: options.fuzzy,
       limit: options.limit,
-      sort: options.sortMiddleware
+      sort: options.sortMiddleware,
+      exclude: options.exclude
     })
 
     if (utils.isJSON(options.json)) {


### PR DESCRIPTION
I found the 'exclude' option doesn't work.

1. The option isn't passed to `Repository` when `SimpleJekyllSearch` is initialized.
I pass the option to `Repository.setOptions()` in `SimpleJekyllSearch` initializer.

2. And the code for checking being excluded is wrong.
I edit the code from `new RegExp(term).test(excludedTerm)` to `new RegExp(excludedTerm).test(term)`.

I purely update the codes in `src` because many lines on other files were edited(like statements, grammars, so on).