### PR TITLE
Add exact match with space usecase

### DIFF
--- a/src/SearchStrategies/LiteralSearchStrategy.js
+++ b/src/SearchStrategies/LiteralSearchStrategy.js
@@ -5,12 +5,9 @@ module.exports = new LiteralSearchStrategy()
 function LiteralSearchStrategy () {
   this.matches = function (str, crit) {
     if (!str) return false
-
     str = str.trim().toLowerCase()
-    crit = crit.trim().toLowerCase()
+    crit = crit.endsWith(' ') ? [crit.toLowerCase()] : crit.trim().toLowerCase().split(' ')
 
-    return crit.split(' ').filter(function (word) {
-      return str.indexOf(word) >= 0
-    }).length === crit.split(' ').length
+    return crit.filter(word => str.indexOf(word) >= 0).length === crit.length
   }
 }

--- a/tests/SearchStrategies/LiteralSearchStrategy.test.js
+++ b/tests/SearchStrategies/LiteralSearchStrategy.test.js
@@ -13,3 +13,19 @@ test('does not match if a word is not contained in the search criteria', t => {
 test('matches a word that is contained in the search criteria (multiple words)', t => {
   t.deepEqual(LiteralSearchStrategy.matches('hello world test search text', 'hello text world'), true)
 })
+
+test('matches exact words when exacts words with space in the search criteria', t => {
+  t.deepEqual(LiteralSearchStrategy.matches('hello world test search text', 'hello world '), true)
+})
+
+test('does not matches multiple words if not exact words with space in the search criteria', t => {
+  t.deepEqual(LiteralSearchStrategy.matches('hello world test search text', 'hello text world '), false)
+})
+
+test('matches a word that is partially contained in the search criteria', t => {
+  t.deepEqual(LiteralSearchStrategy.matches('this tasty tester text', 'test'), true)
+})
+
+test('does not matches a word that is partially contained in the search criteria when followed by a space', t => {
+  t.deepEqual(LiteralSearchStrategy.matches('this tasty tester text', 'test '), false)
+})


### PR DESCRIPTION
Hi @christian-fei 

I have came up with this new use case that could be added to the search.
While using the search I am often looking for something that exactly matches the word I input.

However when for example looking for `test`, if an article had `tester` in it, it would come up too which is okay.
So I thought, if you're looking for `test` only you would do like auto-complete and add a space at then end to specify that the word your looking for is just `test `, the extra space meaning it shouldn't match `tester`.

The same if you are looking for `hello world` and you find results for `hello amazing world`, by adding a space at the end, you mean that you are looking for the exact match like `hello world ` won't return `hello amazing world` only articles with `hello world` in it.

Here would be my implementation of it for the literal search. I have added some test cases so you can see how it works.
Let me know what you think, I could add a note in the documentation if needed.