### PR TITLE
Load results on form submit, instead of on character input

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@
 
   function initWithJSON (json) {
     repository.put(json)
-    
+
     if (options.formSubmit != null) {
       handleSubmit()
     } else {
@@ -101,13 +101,11 @@
     options.resultsContainer.innerHTML += text
   }
 
-
-  function handleSubmit() {
+  function handleSubmit () {
     options.formSubmit.addEventListener('submit', function (e) {
-        e.preventDefault();
-        
-        emptyResultsContainer()
-        debounce(function () { search(options.searchInput.value) }, options.debounceTime)
+      e.preventDefault()
+      emptyResultsContainer()
+      debounce(function () { search(options.searchInput.value) }, options.debounceTime)
     })
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,8 @@
     fuzzy: false,
     debounceTime: null,
     exclude: [],
-    onSearch: Function.prototype
+    onSearch: Function.prototype,
+    formSubmit: null
   }
 
   let debounceTimerHandle

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,12 @@
 
   function initWithJSON (json) {
     repository.put(json)
-    registerInput()
+    
+    if (options.formSubmit != null) {
+      handleSubmit()
+    } else {
+      registerInput()
+    }
   }
 
   function initWithURL (url) {
@@ -94,6 +99,16 @@
 
   function appendToResultsContainer (text) {
     options.resultsContainer.innerHTML += text
+  }
+
+
+  function handleSubmit() {
+    options.formSubmit.addEventListener('submit', function (e) {
+        e.preventDefault();
+        
+        emptyResultsContainer()
+        debounce(function () { search(options.searchInput.value) }, options.debounceTime)
+    })
   }
 
   function registerInput () {


### PR DESCRIPTION
Hi there, thank you for putting the time and effort into writing this repository. I'm currently working on the website of the Dutch CoronaCheck app, which is used for validating and storing certificates of vaccination, a negative test, or recent recovery from covid. Because I wasn't sure how to make the existing solution accessible to pass the WCAG level that we are testing against, I made some changes (as seen in this PR) so if you pass the option `formSubmit`, like so:

```
const sjs = SimpleJekyllSearch({
        searchInput: document.getElementById('search-input'),
        resultsContainer: document.getElementById('results-container'),
        json: '/document.json',
        searchResultTemplate: '<li><a href="{{ site.url }}{url}">{title}</a></li>',
        formSubmit: document.getElementById('search'),
})
```

the code will then check for a submit event from the form with the search ID:

```
<form id="search">
  <label> 
     <input type="text" 
       id="search-input" 
       placeholder="Search blog posts..">
  </label>
  <button>Search</button>
</form>
```

and once the button is triggered, it will then show the results, instead of live. (What I wanted to prevent, is all the results having to be read out loud to someone with a screenreader, or everything moving too fast). 

What do you think?
I was not able to check the input of the field for allowed characters. I hope you can help me with that because as it is workable for my project, I think it would be 'neater' to keep that in. 

If you like this change, let me know and I will submit an edit to the readme as well!
