### PR TITLE
Sorting should be done before limit is applied

### DIFF
--- a/src/Repository.js
+++ b/src/Repository.js
@@ -65,7 +65,7 @@ function search (crit) {
   if (!crit) {
     return []
   }
-  return findMatches(data, crit, opt.searchStrategy, opt).sort(opt.sort)
+  return findMatches(data, crit, opt.searchStrategy, opt).sort(opt.sort).slice(0, opt.limit)
 }
 
 function setOptions (_opt) {
@@ -80,7 +80,7 @@ function setOptions (_opt) {
 
 function findMatches (data, crit, strategy, opt) {
   const matches = []
-  for (let i = 0; i < data.length && matches.length < opt.limit; i++) {
+  for (let i = 0; i < data.length; i++) {
     const match = findMatchesInObject(data[i], crit, strategy, opt)
     if (match) {
       matches.push(match)

--- a/tests/Repository.test.js
+++ b/tests/Repository.test.js
@@ -54,3 +54,29 @@ test('excludes items from search #2', t => {
   })
   t.deepEqual(repository.search('r'), [almostBarElement, barElement, loremElement])
 })
+
+test('sort order for more candidates than limit', t => {
+  const expectedResult1 = { title: 'JavaScript', content: 'JavaScript Awesome' }
+  const expectedResult2 = { title: 'JavaScript', content: 'JavaScript Cool' }
+  const expectedResult3 = { title: 'JavaScript', content: 'JavaScript Easy' }
+  const items = [
+    { title: 'JavaScript', content: 'JavaScript Fun' },
+    { title: 'JavaScript', content: 'JavaScript Rocks' },
+    expectedResult3,
+    { title: 'JavaScript', content: 'JavaScript Powerful' },
+    { title: 'JavaScript', content: 'JavaScript Works' },
+    { title: 'JavaScript', content: 'JavaScript For frontend and backend' },
+    expectedResult2,
+    { title: 'JavaScript', content: 'JavaScript For Jekyll' },
+    expectedResult1
+  ]
+
+  for (let i = 0; i < 5; i++) {
+    // irrespective of the insertion order, the result order should not change
+    repository.clear()
+    items.sort((a, b) => Math.random() - 0.5)// shuffle items
+    repository.put(items)
+    repository.setOptions({ limit: 3, sort: (a, b) => a.content.localeCompare(b.content) })
+    t.deepEqual(repository.search('JavaScript'), [expectedResult1, expectedResult2, expectedResult3])
+  }
+})


### PR DESCRIPTION
If we do not sort the whole candidate list, we might return less relevant results first.
Limit should be applied on the sorted list.