### PR TITLE
Using “concat” filter in full-text search

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,28 +270,16 @@ Replace `search.json` with the following code:
 ---
 layout: none
 ---
+{% assign all_pages = site.posts | concat: site.pages | where_exp: "page", "page.title != nil" %}
 [
-  {% for post in site.posts %}
-    {
-      "title"    : "{{ post.title | escape }}",
-      "category" : "{{ post.category }}",
-      "tags"     : "{{ post.tags | join: ', ' }}",
-      "url"      : "{{ site.baseurl }}{{ post.url }}",
-      "date"     : "{{ post.date }}",
-      "content"  : "{{ post.content | strip_html | strip_newlines }}"
-    } {% unless forloop.last %},{% endunless %}
-  {% endfor %}
-  ,
-  {% for page in site.pages %}
+  {% for page in all_pages %}
    {
-     {% if page.title != nil %}
-        "title"    : "{{ page.title | escape }}",
-        "category" : "{{ page.category }}",
-        "tags"     : "{{ page.tags | join: ', ' }}",
-        "url"      : "{{ site.baseurl }}{{ page.url }}",
-        "date"     : "{{ page.date }}",
-        "content"  : "{{ page.content | strip_html | strip_newlines }}"
-     {% endif %}
+      "title"    : "{{ page.title | escape }}",
+      "category" : "{{ page.category }}",
+      "tags"     : "{{ page.tags | join: ', ' }}",
+      "url"      : "{{ site.baseurl }}{{ page.url }}",
+      "date"     : "{{ page.date }}",
+      "content"  : "{{ page.content | strip_html | strip_newlines }}"
    } {% unless forloop.last %},{% endunless %}
   {% endfor %}
 ]


### PR DESCRIPTION
Instead of repeating the `for` loop in `site.pages` too, it is much more efficient to assign a variable to the array of all pages, using the [`concat` filter](https://shopify.github.io/liquid/filters/concat/) to add more collections to the array, and using [`where_exp` filter](https://jekyllrb.com/docs/liquid/filters/#where-expression) to filter out pages without a title.